### PR TITLE
Fix mishandling of non-ObjectId ids in calls to find_by_id

### DIFF
--- a/mongothon/model.py
+++ b/mongothon/model.py
@@ -2,6 +2,7 @@ from document import Document
 from copy import deepcopy
 from bson import ObjectId
 from middleware import MiddlewareRegistrar
+import re
 import types
 
 
@@ -11,6 +12,7 @@ class ModelState:
     PERSISTED = 2
     DELETED = 3
 
+OBJECTIDEXPR = re.compile(r"^[a-fA-F0-9]{24}$")
 
 class ScopeBuilder(object):
     """A helper class used to build query scopes. This class is provided with a
@@ -107,7 +109,11 @@ def create_model(schema, collection):
             """Checks whether the given id is an ObjectId instance, and if not wraps it."""
             if isinstance(id, ObjectId):
                 return id
-            return ObjectId(id)
+
+            if isinstance(id, basestring) and OBJECTIDEXPR.match(id):
+                return ObjectId(id)
+
+            return id
 
         @classmethod
         def _id_spec(cls, id):

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -197,10 +197,32 @@ class TestModel(TestCase):
     def test_find_by_id(self):
         self.mock_collection.find_one.return_value = doc
         oid = ObjectId()
+        loaded_car = self.Car.find_by_id(oid)
+        self.assertEquals(doc, loaded_car)
+        self.assert_predicates(loaded_car, is_persisted=True)
+        self.mock_collection.find_one.assert_called_with({'_id': oid})
+
+    def test_find_by_id_handles_integer_id(self):
+        self.mock_collection.find_one.return_value = doc
+        loaded_car = self.Car.find_by_id(33)
+        self.assertEquals(doc, loaded_car)
+        self.assert_predicates(loaded_car, is_persisted=True)
+        self.mock_collection.find_one.assert_called_with({'_id': 33})
+
+    def test_find_by_id_handles_oid_as_string(self):
+        self.mock_collection.find_one.return_value = doc
+        oid = ObjectId()
         loaded_car = self.Car.find_by_id(str(oid))
         self.assertEquals(doc, loaded_car)
         self.assert_predicates(loaded_car, is_persisted=True)
         self.mock_collection.find_one.assert_called_with({'_id': oid})
+
+    def test_find_by_id_handles_non_oid_string_id(self):
+        self.mock_collection.find_one.return_value = doc
+        loaded_car = self.Car.find_by_id("bob")
+        self.assertEquals(doc, loaded_car)
+        self.assert_predicates(loaded_car, is_persisted=True)
+        self.mock_collection.find_one.assert_called_with({'_id': "bob"})
 
     def test_reload(self):
         updated_doc = deepcopy(doc)


### PR DESCRIPTION
@byels
