### PR TITLE
Model.find_by_id() now raises a NotFoundException is the record does not exist

### DIFF
--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -1,3 +1,3 @@
 from document import Document
-from model import create_model
-from schema import Schema, Mixed
+from model import create_model, NotFoundException
+from schema import Schema, Mixed, ValidationException

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,8 +1,7 @@
 from mongothon import create_model
 from unittest import TestCase
 from mock import Mock, ANY, call
-from mongothon import Document
-from mongothon import Schema
+from mongothon import Document, Schema, NotFoundException
 from mongothon.validators import one_of
 from mongothon.model import ScopeBuilder
 from bson import ObjectId
@@ -225,6 +224,13 @@ class TestModel(TestCase):
         self.assertEquals(doc, loaded_car)
         self.assert_predicates(loaded_car, is_persisted=True)
         self.mock_collection.find_one.assert_called_with({'_id': oid})
+
+    def test_find_by_id_missing_record(self):
+        """Test that find_by_id throws a NotFoundException if the requested record does not exist"""
+        self.mock_collection.find_one.return_value = None
+        with self.assertRaises(NotFoundException):
+            self.Car.find_by_id(ObjectId())
+
 
     def test_find_by_id_handles_non_oid_string_id(self):
         self.mock_collection.find_one.return_value = doc


### PR DESCRIPTION
This is a concession to the reality that 99% of the time, if you are calling this method you are pretty certain the record exists and if it does not exist you almost always want to bail out. 

Throwing an exception here helps as it saves the caller the boilerplate of needing to check the response. Instead, you can put a global exception handler at the top of your stack and handle the failure appropriately.
