### PR TITLE
Detect circular references in dicts used to populate models

### DIFF
--- a/mongothon/document.py
+++ b/mongothon/document.py
@@ -3,22 +3,35 @@ class Document(dict):
         if initial:
             self.populate(initial)
 
-    def populate(self, from_dict):
-        """Populates this document from the given dict."""
+    def _populate(self, from_dict, seen):
+        if id(from_dict) in seen:
+            raise ValueError("Circular reference detected in dict used to populate Mongothon document")
+        seen.add(id(from_dict))
+
+        def create_doc(value):
+            doc = Document()
+            doc._populate(value, seen)
+            return doc
 
         self.clear()
         for key, value in from_dict.iteritems():
             if isinstance(value, dict):
-                self[key] = Document(value)
+                self[key] = create_doc(value)
 
             elif isinstance(value, list):
                 self[key] = []
                 for item in value:
                     if isinstance(item, dict):
-                        self[key].append(Document(item))
+                        self[key].append(create_doc(item))
                     else:
                         self[key].append(item)
 
             else:
                 self[key] = value
+
+    def populate(self, from_dict):
+        """Populates this document from the given dict."""
+        seen = set()
+        self._populate(from_dict, seen)
+
 

--- a/tests/document_test.py
+++ b/tests/document_test.py
@@ -1,10 +1,11 @@
 from mongothon import Document
 import unittest
 
+
 class TestDocument(unittest.TestCase):
 
-    def _get_document(self):
-        spec = {
+    def get_spec(self):
+        return {
             "author": "John Humphreys",
             "content": {
                 "title": "How to make cookies",
@@ -25,11 +26,14 @@ class TestDocument(unittest.TestCase):
             "tags": ["recipe", "cookies"]
         }
 
-        return Document(spec)
-
-
     def test_creates_nested_document_tree(self):
-        document = self._get_document()
+        document = Document(self.get_spec())
         self.assertIsInstance(document['content'], Document)
         self.assertIsInstance(document['comments'][0], Document)
+
+    def test_reports_circular_references(self):
+        spec = self.get_spec()
+        spec['circular'] = spec
+        with self.assertRaises(ValueError):
+            Document(spec)
 


### PR DESCRIPTION
Raise a helpful error rather than allowing a nasty stack overflow.

@nrschultz 
