### PR TITLE
Updated scopes to properly deep merge queries

### DIFF
--- a/mongothon/model.py
+++ b/mongothon/model.py
@@ -8,6 +8,21 @@ import types
 
 OBJECTIDEXPR = re.compile(r"^[a-fA-F0-9]{24}$")
 
+def deep_merge(source, dest):
+    """Deep merges source dict into dest dict."""
+    for key, value in source.iteritems():
+        if key in dest:
+            if isinstance(value, dict) and isinstance(dest[key], dict):
+                deep_merge(value, dest[key])
+                continue
+            elif isinstance(value, list) and isinstance(dest[key], list):
+                for item in value:
+                    if item not in dest[key]:
+                        dest[key].append(item)
+                continue
+        dest[key] = value
+
+
 class ModelState:
     """Valid lifecycle states which a given Model instance may occupy."""
     NEW = 1
@@ -66,7 +81,7 @@ class ScopeBuilder(object):
                 new_query = deepcopy(self.query)
                 new_projection = deepcopy(self.projection)
                 new_options = deepcopy(self.options)
-                new_query.update(query)
+                deep_merge(query, new_query)
                 new_projection.update(projection)
                 new_options.update(options)
                 return ScopeBuilder(self.model, self.fns, new_query,

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -469,6 +469,35 @@ class TestScopeBuilder(TestCase):
                           bldr.query)
         self.assertEquals({"limit": 10}, bldr.options)
 
+    def test_queries_are_deep_merged_with_chained_scopes(self):
+        mock_model = Mock()
+
+        def scope_a():
+            return {"thing": {"$elemMatch": {'somefield': 1}}}
+
+        def scope_b():
+            return {"thing": {"$elemMatch": {'someotherfield': 10}}}
+
+        bldr = ScopeBuilder(mock_model, [scope_a, scope_b])
+        bldr = bldr.scope_a().scope_b()
+        self.assertEquals({"thing": {"$elemMatch": {'somefield': 1,
+                                                    'someotherfield': 10}}},
+                          bldr.query)
+
+    def test_queries_with_lists_are_deep_merged_with_chained_scopes(self):
+        mock_model = Mock()
+
+        def scope_a():
+            return {"thing": {"$in": [1, 2, 3]}}
+
+        def scope_b():
+            return {"thing": {"$in": [3, 4, 5]}}
+
+        bldr = ScopeBuilder(mock_model, [scope_a, scope_b])
+        bldr = bldr.scope_a().scope_b()
+        self.assertEquals({"thing": {"$in": [1, 2, 3, 4, 5]}},
+                          bldr.query)
+
     def test_calls_back_to_model_on_execute(self):
         mock_model = Mock()
         cursor = Mock()


### PR DESCRIPTION
This ensures multiple chained scopes use a "deep merge" approach when combining queries, rather than the somewhat crude `dict.update` approach used previously. 

This ensures that more complex queries such as those involving `$elemMatch` or `$in` can be combined such that the nested criteria are combined rather than clobbered. 
