### PR TITLE
Allow Document.__init__ and Model.__init__ to take **kwargs

### DIFF
--- a/mongothon/document.py
+++ b/mongothon/document.py
@@ -140,9 +140,11 @@ class Document(dict):
     Subclass of dict which adds some useful functionality around change tracking.
     """
 
-    def __init__(self, initial=None):
+    def __init__(self, initial=None, **kwargs):
         if initial:
-            self.update(initial)
+            self.update(initial, **kwargs)
+        elif kwargs:
+            self.update(**kwargs)
         self.reset_changes()
 
     @property

--- a/mongothon/model.py
+++ b/mongothon/model.py
@@ -47,9 +47,9 @@ class Model(Document):
     PERSISTED = 2
     DELETED = 3
 
-    def __init__(self, inital_doc=None, initial_state=NEW):
+    def __init__(self, inital_doc=None, initial_state=NEW, **kwargs):
         self._state = initial_state
-        super(Model, self).__init__(inital_doc)
+        super(Model, self).__init__(inital_doc, **kwargs)
         self.emit('did_init')
         if initial_state == self.PERSISTED:
             self.emit('did_find')

--- a/tests/mongothon/document_test.py
+++ b/tests/mongothon/document_test.py
@@ -13,6 +13,22 @@ class TestDocument(unittest.TestCase):
         doc = Document()
         self.assertEquals({}, doc)
 
+    def test_init_with_kwargs(self):
+        doc = Document({'a': 'b', 'c': 'd'}, e='f', g='h')
+        self.assertEquals({'a': 'b', 'c': 'd', 'e': 'f', 'g': 'h'}, doc)
+
+    def test_init_with_kwargs_only(self):
+        doc = Document(a='b', c='d')
+        self.assertEquals({'a': 'b', 'c': 'd'}, doc)
+
+    def test_init_with_initial_keyword(self):
+        doc = Document(initial={'a': 'b', 'c': 'd'})
+        self.assertEquals(doc, {'a': 'b', 'c': 'd'})
+
+    def test_init_with_initial_keyword_and_kwargs(self):
+        doc = Document(initial={'a': 'b', 'c': 'd'}, e='f', g='h')
+        self.assertEquals(doc, {'a': 'b', 'c': 'd', 'e': 'f', 'g': 'h'})
+
     def test_set_get(self):
         doc = Document({'a': 'b'})
         self.assertEquals('b', doc['a'])

--- a/tests/mongothon/model_test.py
+++ b/tests/mongothon/model_test.py
@@ -111,6 +111,18 @@ class TestModel(TestCase):
         self.car['make'] = 'volvo'
         self.assertEquals('volvo', self.car['make'])
 
+    def test_constructor_with_kwargs(self):
+        car = self.Car(doc, _id='new_car_id')
+        self.assertEquals('new_car_id', car['_id'])
+
+    def test_constructor_with_kwargs_and_initial_state(self):
+        handler = Mock()
+        self.Car.on('did_find', handler)
+        car = self.Car(doc, initial_state=self.Car.PERSISTED, _id='new_car_id')
+        self.assertEquals('new_car_id', car['_id'])
+        self.assertEquals(self.Car.PERSISTED, car._state)
+        handler.assert_called_once_with(car)
+
     def test_instantiate(self):
         self.assert_predicates(self.car, is_new=True)
 


### PR DESCRIPTION
review @tleach this addresses https://github.com/gamechanger/mongothon/issues/47