### PR TITLE
Index Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ Mongothon.egg-info
 build
 dist
 env
+#*#
+*#
+.#*
+*~

--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -2,7 +2,7 @@ import inspect
 from inflection import camelize
 from document import Document
 from model import Model, NotFoundException
-from schema import Schema
+from schema import Schema, IndexSpec
 from schemer import Mixed, ValidationException, Array
 
 

--- a/mongothon/model.py
+++ b/mongothon/model.py
@@ -141,7 +141,7 @@ class Model(Document):
 
     @classmethod
     def applied_indexes(cls):
-        return cls._existing_indexes()
+        return [i['name'] for i in cls._existing_indexes()]
 
     @classmethod
     def unapplied_indexes(cls):

--- a/mongothon/schema.py
+++ b/mongothon/schema.py
@@ -29,11 +29,11 @@ class Schema(schemer.Schema):
 
     indexes = []
 
-    def __init__(self, doc_spec, **kwargs):
-        super(Schema, self).__init__(doc_spec, **{k:v for k,v in kwargs.iteritems() if k != 'indexes'})
+    def __init__(self, doc_spec, indexes=[], **kwargs):
+        super(Schema, self).__init__(doc_spec, **kwargs)
 
         # Every mongothon schema should expect an ID field.
         if '_id' not in self._doc_spec:
             self._doc_spec['_id'] = {"type": ObjectId}
 
-        self.indexes = [i.validate() for i in kwargs.get('indexes', [])]
+        self.indexes = [i.validate() for i in indexes]

--- a/mongothon/schema.py
+++ b/mongothon/schema.py
@@ -5,9 +5,21 @@ import schemer
 class Schema(schemer.Schema):
     """A Schema encapsulates the structure and constraints of a Mongo document."""
 
+    indexes = []
+
     def __init__(self, doc_spec, **kwargs):
-        super(Schema, self).__init__(doc_spec, **kwargs)
+        super(Schema, self).__init__(doc_spec, **{k:v for k,v in kwargs.iteritems() if k != 'indexes'})
 
         # Every mongothon schema should expect an ID field.
         if '_id' not in self._doc_spec:
             self._doc_spec['_id'] = {"type": ObjectId}
+
+        self.indexes = kwargs.get('indexes', [])
+        self._validate_indexes()
+
+    def _validate_indexes(self):
+        for index in self.indexes:
+            if 'name' not in index:
+                raise KeyError('name')
+            if 'key' not in index:
+                raise KeyError('key')

--- a/tests/mongothon/model_test.py
+++ b/tests/mongothon/model_test.py
@@ -134,6 +134,7 @@ class TestModel(TestCase):
         self.mock_collection.create_index.assert_called_once_with([('make', 1)], name='make_1')
         self.mock_collection.index_information.return_value = {'make_1': {'key': [('make', 1)]}}
         self.assertEqual([], self.Car.unapplied_indexes())
+        self.assertEqual(['make_1'], self.Car.applied_indexes())
 
     def test_validation_of_valid_doc(self):
         self.car.validate()

--- a/tests/mongothon/model_test.py
+++ b/tests/mongothon/model_test.py
@@ -2,7 +2,7 @@ from mongothon import create_model, create_model_offline
 from pickle import dumps, loads
 from unittest import TestCase
 from mock import Mock, ANY, call, NonCallableMock
-from mongothon import Document, Schema, NotFoundException, Array
+from mongothon import Document, Schema, NotFoundException, Array, IndexSpec
 from mongothon.validators import one_of
 from mongothon.scopes import STANDARD_SCOPES
 from bson import ObjectId
@@ -23,7 +23,7 @@ car_schema = Schema({
     }))},
     "options":              {"type": Array(basestring)}
 },
-                    indexes=[{'name': 'make_1', 'key': [('make', 1)]}])
+                    indexes=[IndexSpec('make_1', [('make', 1)])])
 
 
 doc = {

--- a/tests/mongothon/schema_test.py
+++ b/tests/mongothon/schema_test.py
@@ -1,7 +1,7 @@
-from mongothon.schema import Schema
+from mongothon.schema import Schema, IndexSpec
 from mock import Mock
 import unittest
 
 class TestSchema(unittest.TestCase):
     def test_indexes(self):
-        Schema({}, indexes=[{'name': 'myindex', 'key': 'foo'}])
+        Schema({}, indexes=[IndexSpec('myindex', [('key', 1)])])

--- a/tests/mongothon/schema_test.py
+++ b/tests/mongothon/schema_test.py
@@ -1,0 +1,7 @@
+from mongothon.schema import Schema
+from mock import Mock
+import unittest
+
+class TestSchema(unittest.TestCase):
+    def test_indexes(self):
+        Schema({}, indexes=[{'name': 'myindex', 'key': 'foo'}])


### PR DESCRIPTION
Hi @tleach !

I couldn't help but want to fix #1 , because I am trying to use Mongothon for a side project during vacation, and I want to be able to create indexes in a good way like this.

I'm opening this pull request before it's done, because I want to start the dialogue here.
- this has explicit `indexes` support in `mongothon.schema.Schema`
- I am considering adding `"index":True` support to the Schema too
- I have a basic set of tests for checking and applying indexes
- I have very basic index validation

TODO:
- need to create an `IndexSpec` class and use those rather than dicts **DONE**
- need to do better validation that only the normal index types are currently supported **DONE**
- document this functionality

Open to feedback!
