### PR TITLE
Make frame walk correct when called outside of a class

### DIFF
--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -14,11 +14,7 @@ def _module_name_from_previous_frame(num_frames_back):
     """
     frm = inspect.stack()[num_frames_back + 1]
     module = inspect.getmodule(frm[0])
-    if module:
-        return module.__name__
-    else:
-        return None
-
+    return module.__name__ if module else None
 
 def create_model(schema, collection, class_name=None):
     """

--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -13,7 +13,8 @@ def _module_name_from_previous_frame(num_frames_back):
     should be given relative to the caller.
     """
     frm = inspect.stack()[num_frames_back + 1]
-    return inspect.getmodule(frm[0]).__name__
+    module = inspect.getmodule(frm[0])
+    return module.__name__ if module else None
 
 
 def create_model(schema, collection, class_name=None):

--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -13,8 +13,11 @@ def _module_name_from_previous_frame(num_frames_back):
     should be given relative to the caller.
     """
     frm = inspect.stack()[num_frames_back + 1]
-    module = None #inspect.getmodule(frm[0])
-    return module.__name__ if module else None
+    module = inspect.getmodule(frm[0])
+    if module:
+        return module.__name__
+    else:
+        return None
 
 
 def create_model(schema, collection, class_name=None):

--- a/mongothon/__init__.py
+++ b/mongothon/__init__.py
@@ -13,7 +13,7 @@ def _module_name_from_previous_frame(num_frames_back):
     should be given relative to the caller.
     """
     frm = inspect.stack()[num_frames_back + 1]
-    module = inspect.getmodule(frm[0])
+    module = None #inspect.getmodule(frm[0])
     return module.__name__ if module else None
 
 


### PR DESCRIPTION
Mongothon initialization was failing when called outside a class (for instance from an ipython notebook). This is because you don't have a containing class from where you're calling. Added a simple test to see if the getmodule() call returns None, returning None if so. The generated model class won't have a module in this case, but this is not a problem in most cases.